### PR TITLE
semget() may return zero on success

### DIFF
--- a/libexec/Nfsync.pm
+++ b/libexec/Nfsync.pm
@@ -45,7 +45,8 @@ use IPC::SysV qw(IPC_RMID);
 my $semlock;
 
 sub seminit {
-	$semlock = semget(IPC_PRIVATE, 1, 0600 | IPC_CREAT ) || die "Can not get semaphore: $!";
+	$semlock = semget(IPC_PRIVATE, 1, 0600 | IPC_CREAT );
+	die "Can not get semaphore: $!" if !defined($semlock);
 	semsignal($semlock);
 } # End of seminit
 


### PR DESCRIPTION
The semaphore ID may be zero.

> \# ipcs -s
> ------ Semaphore Arrays --------
> key        semid      owner      perms      nsems
> 0x00000000 0          root       600        1